### PR TITLE
Failed on MySQL-5.0.45

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -170,11 +170,13 @@ sub setup {
     # mysql_install_db
     if (! -d $self->base_dir . '/var/mysql') {
         my $cmd = $self->mysql_install_db;
+        # We should specify --defaults-file option first.
+        $cmd .= " --defaults-file='" . $self->base_dir . "/etc/my.cnf'";
         my $mysql_base_dir = $self->mysql_install_db;
         if ($mysql_base_dir =~ s|/[^/]+/mysql_install_db$||) {
             $cmd .= " --basedir='$mysql_base_dir'";
         }
-        $cmd .= " --defaults-file='" . $self->base_dir . "/etc/my.cnf' 2>&1";
+        $cmd .= " 2>&1";
         open $fh, '-|', $cmd
             or die "failed to spawn mysql_install_db:$!";
         my $output;


### PR DESCRIPTION
Some tests failed on MySQL-5.0.45 in my environment.

% make test

.... snip ....

t/01-raii.t .......... **\* mysql_install_db failed ***
Installing MySQL system tables...
110214 12:08:32 [ERROR] /usr/local/mysql/bin/mysqld: unknown variable 'defaults-
file=/var/folders/9n/9n5HlmC0EU4hs8TknVQXLk+++TI/-Tmp-/zKAK0kAwii/etc/my.cnf'

Installation of system tables failed!

.... snip ....
## Test Summary Report

t/01-raii.t        (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
t/02-multi.t       (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP outputt/04-multiprocess.t (Wstat: 256 Tests: 0 Failed: 0)
  Non-zero exit status: 1
  Parse errors: No plan found in TAP output
Files=5, Tests=4,  3 wallclock secs ( 0.05 usr  0.03 sys +  0.62 cusr  0.30 csys =  1.00 CPU)
Result: FAIL
Failed 3/5 test programs. 0/4 subtests failed.
make: **\* [test_dynamic] Error 1

This patch fixes it.
