### PR TITLE
$? should be left in tact after calling stop()

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -138,6 +138,8 @@ sub start {
 
 sub stop {
     my ($self, $sig) = @_;
+
+    local $?; # waitpid may change this value :/
     return
         unless defined $self->pid;
     $sig ||= SIGTERM;

--- a/t/01-raii.t
+++ b/t/01-raii.t
@@ -11,7 +11,7 @@ my $mysqld = Test::mysqld->new(
     },
 ) or plan skip_all => $Test::mysqld::errstr;
 
-plan tests => 3;
+plan tests => 4;
 
 my $base_dir = $mysqld->base_dir;
 my $dsn = $mysqld->dsn;
@@ -25,6 +25,9 @@ is(
 my $dbh = DBI->connect($dsn);
 ok($dbh, 'connect to mysqld');
 
+local $? = 255; # dummy vale
 undef $mysqld;
 sleep 1; # just in case
+
+is($?, 255, "\$? is left in tact");
 ok(! -e "$base_dir/tmp/mysql.sock", "mysqld is down");


### PR DESCRIPTION
Ditto.

I was using this in my make test, and $? got clobbered, making the test runner
think that the test actually passed when it had clearly failed.

Thanks in advance!
