### PR TITLE
added "sbin" to mysqld subdirs for "/usr/sbin/mysqld"

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -57,7 +57,7 @@ sub new {
         $self->mysql_install_db($prog);
     }
     if (! defined $self->mysqld) {
-        my $prog = _find_program(qw/mysqld bin libexec/)
+        my $prog = _find_program(qw/mysqld bin libexec sbin/)
             or return;
         $self->mysqld($prog);
     }


### PR DESCRIPTION
MySQL-community 版だと /usr/sbin/mysqld がデフォだと思うので、ハマってしまいました。
