### PR TITLE
Use MySQL option --tmpdir to prevent multiple MySQL processes clashing.

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -109,6 +109,7 @@ sub start {
         exec(
             $self->mysqld,
             '--defaults-file=' . $self->base_dir . '/etc/my.cnf',
+            '--tmpdir=' . $self->base_dir . '/tmp',
             '--user=root',
         );
         die "failed to launch mysqld:$?";
@@ -174,6 +175,7 @@ sub setup {
         my $cmd = $self->mysql_install_db;
         # We should specify --defaults-file option first.
         $cmd .= " --defaults-file='" . $self->base_dir . "/etc/my.cnf'";
+        $cmd .= " --tmpdir='" . $self->base_dir . "/tmp'";
         my $mysql_base_dir = $self->mysql_install_db;
         if ($mysql_base_dir =~ s|/[^/]+/mysql_install_db$||) {
             $cmd .= " --basedir='$mysql_base_dir'";


### PR DESCRIPTION
- added --tmpdir option to mysql commands in saetup and start methods.

Without the --tmpdir option it seems MySQL creates temporary files in the system tmp dir without much randomisation of the file names. I easily got clashes when running parrallel tests with prove -j 9. I got the same errors with your own tests using this option. With --tmpdir set I'm not seeing these issues.

I think I've fixed it with these changes, but please be sure to check it out for yourself.

cheers,

J
