### PR TITLE
Use MySQL option --tmpdir to prevent multiple MySQL processes clashing.

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -109,6 +109,7 @@ sub start {
         exec(
             $self->mysqld,
             '--defaults-file=' . $self->base_dir . '/etc/my.cnf',
+            '--tmpdir=' . $self->base_dir . '/tmp',
             '--user=root',
         );
         die "failed to launch mysqld:$?";
@@ -174,6 +175,7 @@ sub setup {
         my $cmd = $self->mysql_install_db;
         # We should specify --defaults-file option first.
         $cmd .= " --defaults-file='" . $self->base_dir . "/etc/my.cnf'";
+        $cmd .= " --tmpdir='" . $self->base_dir . "/tmp'";
         my $mysql_base_dir = $self->mysql_install_db;
         if ($mysql_base_dir =~ s|/[^/]+/mysql_install_db$||) {
             $cmd .= " --basedir='$mysql_base_dir'";

--- a/t/10-parallel-tmp-tables.t
+++ b/t/10-parallel-tmp-tables.t
@@ -1,0 +1,25 @@
+# run the parallel-tmp-tables tests in parallel.. with:
+# prove -j4 t/1*
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use Test::mysqld;
+
+my $mysqld = Test::mysqld->new(
+    my_cnf => {
+        'skip-networking' => '',
+    },
+) or plan skip_all => $Test::mysqld::errstr;
+
+plan tests => 3;
+
+my $dsn = $mysqld->dsn;
+
+my $dbh = DBI->connect($dsn);
+
+ok $dbh->do("CREATE TEMPORARY TABLE t (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("CREATE TEMPORARY TABLE t2 (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("select * from t,t2") => 'select';

--- a/t/11-parallel-tmp-tables.t
+++ b/t/11-parallel-tmp-tables.t
@@ -1,0 +1,25 @@
+# run the parallel-tmp-tables tests in parallel.. with:
+# prove -j4 t/1*
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use Test::mysqld;
+
+my $mysqld = Test::mysqld->new(
+    my_cnf => {
+        'skip-networking' => '',
+    },
+) or plan skip_all => $Test::mysqld::errstr;
+
+plan tests => 3;
+
+my $dsn = $mysqld->dsn;
+
+my $dbh = DBI->connect($dsn);
+
+ok $dbh->do("CREATE TEMPORARY TABLE t (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("CREATE TEMPORARY TABLE t2 (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("select * from t,t2") => 'select';

--- a/t/12-parallel-tmp-tables.t
+++ b/t/12-parallel-tmp-tables.t
@@ -1,0 +1,25 @@
+# run the parallel-tmp-tables tests in parallel.. with:
+# prove -j4 t/1*
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use Test::mysqld;
+
+my $mysqld = Test::mysqld->new(
+    my_cnf => {
+        'skip-networking' => '',
+    },
+) or plan skip_all => $Test::mysqld::errstr;
+
+plan tests => 3;
+
+my $dsn = $mysqld->dsn;
+
+my $dbh = DBI->connect($dsn);
+
+ok $dbh->do("CREATE TEMPORARY TABLE t (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("CREATE TEMPORARY TABLE t2 (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("select * from t,t2") => 'select';

--- a/t/13-parallel-tmp-tables.t
+++ b/t/13-parallel-tmp-tables.t
@@ -1,0 +1,25 @@
+# run the parallel-tmp-tables tests in parallel.. with:
+# prove -j4 t/1*
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use Test::mysqld;
+
+my $mysqld = Test::mysqld->new(
+    my_cnf => {
+        'skip-networking' => '',
+    },
+) or plan skip_all => $Test::mysqld::errstr;
+
+plan tests => 3;
+
+my $dsn = $mysqld->dsn;
+
+my $dbh = DBI->connect($dsn);
+
+ok $dbh->do("CREATE TEMPORARY TABLE t (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("CREATE TEMPORARY TABLE t2 (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("select * from t,t2") => 'select';

--- a/t/14-parallel-tmp-tables.t
+++ b/t/14-parallel-tmp-tables.t
@@ -1,0 +1,25 @@
+# run the parallel-tmp-tables tests in parallel.. with:
+# prove -j4 t/1*
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use Test::mysqld;
+
+my $mysqld = Test::mysqld->new(
+    my_cnf => {
+        'skip-networking' => '',
+    },
+) or plan skip_all => $Test::mysqld::errstr;
+
+plan tests => 3;
+
+my $dsn = $mysqld->dsn;
+
+my $dbh = DBI->connect($dsn);
+
+ok $dbh->do("CREATE TEMPORARY TABLE t (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("CREATE TEMPORARY TABLE t2 (a int, b int, c int) ENGINE MYISAM") => 'created tmp table';
+ok $dbh->do("select * from t,t2") => 'select';


### PR DESCRIPTION
- added --tmpdir option to mysql commands in setup and start methods.

Without the --tmpdir option MySQL creates temporary files in the system tmp dir without much randomisation of the file names. I easily got clashes when running parrallel tests with prove -j4.
I have added some tests which should be run in parallel with `prove -j4 t/1*`.
Without the tmpdir set, most of the time at least one of these tests will crash.
With tmpdir set I'm not seeing these issues.

I think I've fixed it with these changes, but please be sure to check it out for yourself.

cheers,

J
