### PR TITLE
Move the "Already Running" error inside the auto_start block

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -62,9 +62,9 @@ sub new {
             or return;
         $self->mysqld($prog);
     }
-    die 'mysqld is already running (' . $self->my_cnf->{'pid-file'} . ')'
-        if -e $self->my_cnf->{'pid-file'};
     if ($self->auto_start) {
+        die 'mysqld is already running (' . $self->my_cnf->{'pid-file'} . ')'
+            if -e $self->my_cnf->{'pid-file'};
         $self->setup
             if $self->auto_start >= 2;
         $self->start;


### PR DESCRIPTION
This is a tiny patch that moves the "Already Running" error a few lines down so that we only issue it IF we are asked to start a database.  That way one can use Test::mysqld to use a database that is already running and created by a previous call to Test::mysqld.

This lets you set auto_start to 0 and skip trying to start the database, without hitting that error message.  My use case for this is in DBIx::Class::Migration when a user is using the test database for running upgrades and downgrades but does not want to stop the database first.  I also think this change would give you a bit of added flexibility when desiring to run tests against a running database.

Thanks!  I've been making great use of your module for Test::DBIx::Class and now DBIx::Class::Migration and ti has really helped me.
