### PR TITLE
Resolve real absolute path if prog path is a symbolic link in `_get_path_of`

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -176,6 +176,12 @@ sub setup {
         # We should specify --defaults-file option first.
         $cmd .= " --defaults-file='" . $self->base_dir . "/etc/my.cnf'";
         my $mysql_base_dir = $self->mysql_install_db;
+        if (-l $mysql_base_dir) {
+            require File::Spec;
+            require File::Basename;
+            my $base = File::Basename::dirname($mysql_base_dir);
+            $mysql_base_dir = File::Spec->rel2abs(readlink($mysql_base_dir), $base);
+        }
         if ($mysql_base_dir =~ s|/[^/]+/mysql_install_db$||) {
             $cmd .= " --basedir='$mysql_base_dir'";
         }
@@ -220,13 +226,6 @@ sub _get_path_of {
         if $path;
     $path = ''
         unless -x $path;
-
-    if (-l $path) {
-        require File::Spec;
-        require File::Basename;
-        my $base = File::Basename::dirname($path);
-        $path = File::Spec->rel2abs(readlink($path), $base);
-    }
     $path;
 }
 


### PR DESCRIPTION
In current implement, `$mysql_basedir` resolving possibly fail if mysql_install_db
is a symbolic link.

In my case, I'm using MySQL 5.6.10 homebrew installed in OSX upgraded from
5.5.28 and `which mysql_install_db` returns '/usr/local/bin/mysql_install_db',
but this is a symlink to '../Cellar/mysql/5.6.10/bin/mysql_install_db',
and `$mysql_basedir` resolving will fail.

Then I wrote this patch, but I have not so confident if is this patch appropriate or not.
