### PR TITLE
Adding optional environment variables for setting mysqld and mysqld_inst...

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -21,8 +21,8 @@ my %Defaults = (
     auto_start       => 2,
     base_dir         => undef,
     my_cnf           => {},
-    mysql_install_db => undef,
-    mysqld           => undef,
+    mysql_install_db => undef || $ENV{TEST_MYSQLD_INSTALL_DB},
+    mysqld           => undef || $ENV{TEST_MYSQLD_PATH},
     pid              => undef,
     copy_data_from   => undef,
     _owner_pid       => undef,
@@ -315,6 +315,14 @@ Setups the mysqld instance.
 =head2 read_log
 
 Returns the contents of the mysqld log file.
+
+=head1 ENVIRONMENT VARIABLES
+
+=head2 TEST_MYSQLD_PATH
+
+=head2 TEST_MYSQLD_INSTALL_DB
+
+Path to C<mysql_install_db> script or C<mysqld> program bundled to the mysqld distribution.  If set will overwrite the default search. Passing either option to the constructor takes precedence over these environment variables.
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
I'm using CentOS 6.2 and running Test::mysqld causes the script to hang forever because of the scripts that ship with the mysql-server package.

This change allows me to set environment variables that will point to the proper places so I don't run into this problem in my or other peoples tests.

I'd also like to write some code that could read these options from a config file if it exists but though this would be a good first step. If you're interested in willing to me adding a config file option please let me know.

Thanks
