### PR TITLE
Add a run_sql Method

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,7 +6,6 @@ all_from 'lib/Test/mysqld.pm';
 
 requires 'Class::Accessor::Lite';
 requires 'File::Copy::Recursive';
-requires 'Path::Tiny';
 test_requires 'DBI';
 test_requires 'DBD::mysql';
 test_requires 'Test::SharedFork' => 0.06;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -6,6 +6,7 @@ all_from 'lib/Test/mysqld.pm';
 
 requires 'Class::Accessor::Lite';
 requires 'File::Copy::Recursive';
+requires 'Path::Tiny';
 test_requires 'DBI';
 test_requires 'DBD::mysql';
 test_requires 'Test::SharedFork' => 0.06;

--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -19,7 +19,7 @@ our $errstr;
 our @SEARCH_PATHS = qw(/usr/local/mysql);
 
 my %Defaults = (
-    auto_start       => 3,
+    auto_start       => 2,
     base_dir         => undef,
     my_cnf           => {},
     mysql_install_db => undef,
@@ -72,8 +72,6 @@ sub new {
         $self->setup
             if $self->auto_start >= 2;
         $self->start;
-        $self->run_sql
-            if $self->auto_start >= 3;
     }
     $self;
 }
@@ -134,6 +132,7 @@ sub start {
         $dbh->do('CREATE DATABASE IF NOT EXISTS test')
             or die $dbh->errstr;
     }
+    $self->run_sql;
 }
 
 sub run_sql {

--- a/t/06-run-sql.t
+++ b/t/06-run-sql.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use Test::mysqld;
+
+my $mysqld = Test::mysqld->new(
+    my_cnf         => {
+        'skip-networking' => '',
+    },
+    run_sql_commands => [ 't/06-run-sql/deploy.sql' ],
+) or plan skip_all => $Test::mysqld::errstr;
+
+plan tests => 2;
+
+my $dbh = DBI->connect($mysqld->dsn)
+    or die "failed to connect to database:$DBI::errstr";
+
+is_deeply(
+    $dbh->selectall_arrayref(
+        "SELECT id FROM example WHERE id = 20",
+    ),
+    [ [ 20 ] ],
+);
+
+is_deeply(
+    $dbh->selectall_arrayref(
+        "SELECT id FROM example WHERE id = 30",
+    ),
+    [],
+);

--- a/t/06-run-sql/deploy.sql
+++ b/t/06-run-sql/deploy.sql
@@ -1,0 +1,5 @@
+CREATE TABLE `example` ( `id` INT(11) NOT NULL PRIMARY KEY );
+
+INSERT INTO `example` ( `id` ) VALUES ( 1 );
+
+INSERT INTO `example` ( `id` ) VALUES ( 20 );


### PR DESCRIPTION
I often find myself wanting to run SQL commands during Test::mysqld initialisation.  Although copy_data() does this, sometimes I want to distribute human readable SQL files rather than binary databases.  I realise human readable files take longer to run, but sometimes the benefit of not having binary files outweighs this.

So, I've sent along some code I've been using.  I'd appreciate it if you would consider including this in Test::mysqld.  If you'd like me to change this or improve it further, please let me know.
