### PR TITLE
Intialize Database Fix

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -154,14 +154,6 @@ sub setup {
     for my $subdir (qw/etc var tmp/) {
         mkdir $self->base_dir . "/$subdir";
     }
-    # copy data files
-    if ($self->copy_data_from) {
-        dircopy($self->copy_data_from, $self->my_cnf->{datadir})
-            or die(
-                "could not dircopy @{[$self->copy_data_from]} to "
-                    . "@{[$self->my_cnf->{datadir}]}:$!"
-                );
-    }
     # my.cnf
     open my $fh, '>', $self->base_dir . '/etc/my.cnf'
         or die "failed to create file:" . $self->base_dir . "/etc/my.cnf:$!";
@@ -182,7 +174,6 @@ sub setup {
             $cmd .= " --defaults-file='" . $self->base_dir . "/etc/my.cnf'";
             $cmd .= " --basedir='" . $self->base_dir . "'";
             $cmd .= " --datadir='" . $self->base_dir . "/var'";
-            # must be last!
             $cmd .= " --initialize-insecure";
         } else {
             $cmd = $self->mysql_install_db;
@@ -207,6 +198,14 @@ sub setup {
         }
         close $fh
             or die "*** mysql_install_db failed ***\n$output\n";
+    }
+    # copy data files
+    if ($self->copy_data_from) {
+        dircopy($self->copy_data_from, $self->my_cnf->{datadir})
+            or die(
+                "could not dircopy @{[$self->copy_data_from]} to "
+                    . "@{[$self->my_cnf->{datadir}]}:$!"
+                );
     }
 }
 

--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -64,6 +64,7 @@ sub new {
             or return;
         $self->mysqld($prog);
     }
+    if ($self->_is_mariadb) { $self->my_cnf->{'skip-grant-tables'} = ''; }
     if ($self->auto_start) {
         die 'mysqld is already running (' . $self->my_cnf->{'pid-file'} . ')'
             if -e $self->my_cnf->{'pid-file'};
@@ -214,6 +215,15 @@ sub read_log {
     open my $logfh, '<', $self->base_dir . '/tmp/mysqld.log'
         or die "failed to open file:tmp/mysql.log:$!";
     do { local $/; <$logfh> };
+}
+
+sub _is_mariadb {
+    my ($self) = @_;
+
+    my $version = `${\$self->mysqld} -V`;
+
+    return 1 if $version =~ /MariaDB/;
+    return 0;
 }
 
 sub _use_initialize {


### PR DESCRIPTION
These commits improve compatibility with versions of MySQL > 5.5, as well as MariaDB.

The main changes were required due to a change in MySQL > 5.5 using a different method of creating a database - mysql_install_db has been deprecated, and now you must initialize a new MySQL instance using `--initialize` as an option to the main software. Some of the other changes are listed below:
- Dropping 'secure by default' settings on both MariaDB, and MySQL > 5.5 - this stopped it auto generating a root password, and/or locking out the 'root' user when UID does not match.
  - For MariaDB, this was done by adding 'skip-grant-tables' to the configuration
  - For MySQL > 5.5, this was done by passing the option '--initialize-insecure' to the database creation line.
- Moving the copying of pre-made data (used during testing, and possibly other modes) to after the initialisation of the database. This is due to several of the mysqld versions complaining about files being present in the target folder, and failing the initialisation.

Please note that this development was done against Debian (and Ubuntu) systems, and makes assumptions about the version string format which have not been checked against other distributions, or against any of the *BSDs - if changes are required to cover compatibility with those systems, then please provide example version strings (taken from `mysqld -V`) so that the regex can be updated.
