### PR TITLE
do `copy_data_from` before launching mysqld when using `mysql_install_db`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: perl
 perl:
-    - 5.14
-    - 5.20
-    - 5.22
+    - "5.14"
+    - "5.22"
+    - "5.24"
 env:
   - "DATABASE_ADAPTER=mysql-5.5"
   - "DATABASE_ADAPTER=mysql-5.6"
@@ -32,4 +32,4 @@ before_install:
 install:
   - cpanm --installdeps --notest .
 script:
-  - prove -lv
+  - prove -lvr

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,30 +6,14 @@ perl:
 env:
   - "DATABASE_ADAPTER=mysql-5.5"
   - "DATABASE_ADAPTER=mysql-5.6"
-  - "DATABASE_ADAPTER=mysql-5.7-dmr"
+  - "DATABASE_ADAPTER=mysql-5.7"
   - "DATABASE_ADAPTER=mariadb-10.0"
 before_install:
   - "sudo apt-get update -qq"
-  - if [[ $DATABASE_ADAPTER =~ (mariadb|mysql-5\.[67]) ]] ;
-    then
-      sudo service mysql stop ;
-      sudo apt-get install python-software-properties ;
-      if [[ $DATABASE_ADAPTER =~ mariadb ]] ;
-      then
-        sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db ;
-        sudo add-apt-repository 'deb http://ftp.osuosl.org/pub/mariadb/repo/10.0/ubuntu precise main' ;
-        sudo apt-get update ;
-        sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mariadb-server ;
-        sudo apt-get install libmariadbd-dev ;
-      else
-        echo mysql-apt-config mysql-apt-config/enable-repo select $DATABASE_ADAPTER | sudo debconf-set-selections ;
-        wget http://dev.mysql.com/get/mysql-apt-config_0.2.1-1ubuntu12.04_all.deb ;
-        sudo dpkg --install mysql-apt-config_0.2.1-1ubuntu12.04_all.deb ;
-        sudo apt-get update -q ;
-        sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server ;
-      fi
-    fi
+  - bash author/travis_install_mysql.sh
 install:
   - cpanm --installdeps --notest .
+before_script:
+  - mysql --version
 script:
   - prove -lvr

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -13,3 +13,4 @@
 ^t/9\d_.*\.t
 \.svn/
 \.git/
+author/

--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+if [[ $DATABASE_ADAPTER =~ (mariadb|mysql-5\.[67]) ]]; then
+  sudo service mysql stop
+  sudo apt-get install python-software-properties
+  if [[ $DATABASE_ADAPTER =~ mariadb ]]; then
+    sudo apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a1bb943db
+    sudo add-apt-repository 'deb http://ftp.osuosl.org/pub/mariadb/repo/10.0/ubuntu precise main' ;
+    sudo apt-get update
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mariadb-server
+    sudo apt-get install libmariadbd-dev
+  else
+    echo mysql-apt-config mysql-apt-config/select-server select $DATABASE_ADAPTER | sudo debconf-set-selections
+    wget http://dev.mysql.com/get/mysql-apt-config_0.2.1-1ubuntu12.04_all.deb
+    sudo dpkg --install mysql-apt-config_0.2.1-1ubuntu12.04_all.deb
+    sudo apt-get update -q
+    sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
+  fi
+  sudo mysql_upgrade
+fi

--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -61,8 +61,7 @@ sub new {
         $self->mysqld($prog);
     }
     if (! defined $self->use_mysqld_initialize) {
-        my $supported = $self->_use_mysqld_initialize;
-        $self->use_mysqld_initialize($supported);
+        $self->use_mysqld_initialize($self->_use_mysqld_initialize);
     }
     if ($self->auto_start) {
         die 'mysqld is already running (' . $self->my_cnf->{'pid-file'} . ')'
@@ -261,15 +260,7 @@ sub _use_mysqld_initialize {
     my $self = shift;
 
     my $mysqld = $self->mysqld;
-    my $ret = `$mysqld --verbose --help`;
-    return $self->_parse_mysqld_verbose_help($ret);
-}
-
-sub _parse_mysqld_verbose_help{
-    my $self = shift;
-    my $str  = shift;
-    return 1 if $str =~ /^initialize-insecure\s+FALSE$/m;
-    return;
+    `$mysqld --verbose --help` =~ /--initialize-insecure/ms;
 }
 
 sub _get_path_of {

--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -64,7 +64,6 @@ sub new {
         my $supported = $self->_use_mysqld_initialize;
         $self->use_mysqld_initialize($supported);
     }
-    warn sprintf "use_mysqld_initialize: %s\n", $self->use_mysqld_initialize;
     if ($self->auto_start) {
         die 'mysqld is already running (' . $self->my_cnf->{'pid-file'} . ')'
             if -e $self->my_cnf->{'pid-file'};

--- a/t/05-copy-data-from.t
+++ b/t/05-copy-data-from.t
@@ -4,7 +4,6 @@ use warnings;
 use DBI;
 use Test::More;
 use Test::mysqld;
-use Test::SharedFork;
 
 my $mysqld = Test::mysqld->new(
     auto_start     => undef,


### PR DESCRIPTION
When using `mysql_install_db`, copy the data before setup db for quick bootstrap.
But `mysqld --initialize-insecure` doesn't work while the data dir exists,
so don't copy before and do after setup db.