### PR TITLE
Suppress noisy warnings

### DIFF
--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -11,9 +11,12 @@ if [[ $DATABASE_ADAPTER =~ (mariadb|mysql-5\.[67]) ]]; then
     sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mariadb-server
     sudo apt-get install libmariadbd-dev
   else
-    echo mysql-apt-config mysql-apt-config/select-server select $DATABASE_ADAPTER | sudo debconf-set-selections
-    wget http://dev.mysql.com/get/mysql-apt-config_0.2.1-1ubuntu12.04_all.deb
-    sudo dpkg --install mysql-apt-config_0.2.1-1ubuntu12.04_all.deb
+    cat <<EOC | sudo debconf-set-selections
+mysql-apt-config mysql-apt-config/select-server select $DATABASE_ADAPTER
+mysql-apt-config mysql-apt-config/repo-distro   select  ubuntu
+EOC
+    wget https://dev.mysql.com/get/mysql-apt-config_0.8.4-1_all.deb
+    sudo dpkg --install mysql-apt-config_0.8.4-1_all.deb
     sudo apt-get update -q
     sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
   fi

--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -288,7 +288,7 @@ sub _use_mysqld_initialize {
     my $self = shift;
 
     my $mysqld = $self->mysqld;
-    `$mysqld --verbose --help` =~ /--initialize-insecure/ms;
+    `$mysqld --verbose --help 2>/dev/null` =~ /--initialize-insecure/ms;
 }
 
 sub _get_path_of {


### PR DESCRIPTION
This PR suppresses noisy warnings.

`mysqld --verbose --help` output several warnings to stderr. eg: https://travis-ci.org/kazuho/p5-test-mysqld/jobs/185381213

```
./t/01-raii.t ............ 2016-12-20 07:42:55 0 [Warning] Can't create test file /var/lib/mysql/testing-gce-abf0d97d-0225-41a9-ba0b-161080a9907b.lower-test
2016-12-20 07:42:55 0 [Note] /usr/sbin/mysqld (mysqld 5.6.35) starting as process 8772 ...
2016-12-20 07:42:55 8772 [Warning] Can't create test file /var/lib/mysql/testing-gce-abf0d97d-0225-41a9-ba0b-161080a9907b.lower-test
2016-12-20 07:42:55 8772 [Warning] Can't create test file /var/lib/mysql/testing-gce-abf0d97d-0225-41a9-ba0b-161080a9907b.lower-test
/usr/sbin/mysqld: Can't change dir to '/var/lib/mysql/' (Errcode: 13 - Permission denied)
2016-12-20 07:42:55 8772 [Warning] One can only use the --user switch if running as root
2016-12-20 07:42:55 8772 [Note] Plugin 'FEDERATED' is disabled.
/usr/sbin/mysqld: Table 'mysql.plugin' doesn't exist
2016-12-20 07:42:55 8772 [ERROR] Can't open the mysql.plugin table. Please run mysql_upgrade to create it.
2016-12-20 07:42:55 8772 [Note] Binlog end
2016-12-20 07:42:55 8772 [Note] Shutting down plugin 'CSV'
2016-12-20 07:42:55 8772 [Note] Shutting down plugin 'MyISAM'
```

These warnings are very noisy and useless especially testing by `prove -r t` on terminal.


Or we might as well check version using `mysqld --version`. Addtionally it's faster than `mysqld --verbose --help`.

```
$ time mysqld --verbose --help
...
real    0m0.033s
user    0m0.015s
sys     0m0.005s

$ time mysqld --version
mysqld  Ver 5.6.20 for linux-glibc2.5 on x86_64 (MySQL Community Server (GPL))

real    0m0.006s
user    0m0.006s
sys     0m0.000s
```


