### PR TITLE
Fix basedir detection.

### DIFF
--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -21,6 +21,7 @@ EOC
     sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
   else
     # 5.5
+    sudo apt-get update -q
     sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql55-server
   fi
   sudo mysql_upgrade

--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -22,7 +22,7 @@ EOC
   else
     # 5.5
     sudo apt-get update -q
-    sudo rm -f /var/lib/mysql/debian-*.flag # for downgrade
+    sudo rm -rf /var/lib/mysql/debian-5.6.flag # for downgrade
     sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql-server-5.5 mysql-client-5.5 mysql-server-core-5.5
   fi
   sudo mysql_upgrade

--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -10,7 +10,7 @@ if [[ $DATABASE_ADAPTER =~ (mariadb|mysql-5\.[567]) ]]; then
     sudo apt-get update
     sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mariadb-server
     sudo apt-get install libmariadbd-dev
-  else
+  elif [[ $DATABASE_ADAPTER =~ mysql-5\.[67] ]]; then
     cat <<EOC | sudo debconf-set-selections
 mysql-apt-config mysql-apt-config/select-server select $DATABASE_ADAPTER
 mysql-apt-config mysql-apt-config/repo-distro   select  ubuntu
@@ -19,6 +19,9 @@ EOC
     sudo dpkg --install mysql-apt-config_0.8.4-1_all.deb
     sudo apt-get update -q
     sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
+  else
+    # 5.5
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql55-server
   fi
   sudo mysql_upgrade
 fi

--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -24,6 +24,7 @@ EOC
     sudo apt-get update -q
     sudo rm -rf /var/lib/mysql/ # for downgrade
     sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql-server-5.5 mysql-client-5.5 mysql-server-core-5.5
+    exit # no need to upgrade
   fi
   sudo mysql_upgrade
 fi

--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -21,8 +21,8 @@ EOC
     sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
   else
     # 5.5
-    sudo rm -f /var/lib/mysql/debian-*.flag # for downgrade
     sudo apt-get update -q
+    sudo rm -f /var/lib/mysql/debian-*.flag # for downgrade
     sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql-server-5.5 mysql-client-5.5 mysql-server-core-5.5
   fi
   sudo mysql_upgrade

--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -21,8 +21,9 @@ EOC
     sudo apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
   else
     # 5.5
+    sudo rm -f /var/lib/mysql/debian-*.flag # for downgrade
     sudo apt-get update -q
-    sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql-server-5.5
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql-server-5.5 mysql-client-5.5 mysql-server-core-5.5
   fi
   sudo mysql_upgrade
 fi

--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -22,7 +22,7 @@ EOC
   else
     # 5.5
     sudo apt-get update -q
-    sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql55-server
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql-server-5.5
   fi
   sudo mysql_upgrade
 fi

--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -22,7 +22,7 @@ EOC
   else
     # 5.5
     sudo apt-get update -q
-    sudo rm -rf /var/lib/mysql/debian-5.6.flag # for downgrade
+    sudo rm -rf /var/lib/mysql/ # for downgrade
     sudo DEBIAN_FRONTEND=noninteractive apt-get -q --yes --force-yes -f --option DPkg::Options::=--force-confnew install mysql-server-5.5 mysql-client-5.5 mysql-server-core-5.5
   fi
   sudo mysql_upgrade

--- a/author/travis_install_mysql.sh
+++ b/author/travis_install_mysql.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-if [[ $DATABASE_ADAPTER =~ (mariadb|mysql-5\.[67]) ]]; then
+if [[ $DATABASE_ADAPTER =~ (mariadb|mysql-5\.[567]) ]]; then
   sudo service mysql stop
   sudo apt-get install python-software-properties
   if [[ $DATABASE_ADAPTER =~ mariadb ]]; then

--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -227,7 +227,7 @@ sub setup {
                 my $base = File::Basename::dirname($mysql_base_dir);
                 $mysql_base_dir = File::Spec->rel2abs(readlink($mysql_base_dir), $base);
             }
-            if ($mysql_base_dir =~ s|/[^/]+/mysql_install_db$||) {
+            if ($mysql_base_dir =~ s{/(?:bin|extra)/mysql_install_db$}{}) {
                 $cmd .= " --basedir='$mysql_base_dir'";
             }
         }


### PR DESCRIPTION
At Amazon Linux, mysql_install_db is a symlink to /etc/alternatives/mysql_install_db.
Test::mysqld follows symlink of mysql_install_db and set --basedir='/etc'.
It doesn't work.

```
*** mysql_install_db failed ***

FATAL ERROR: Could not find my_print_defaults

The following directories were searched:

    /etc/bin
    /etc/extra
```

mysql_install_db(shell script on 5.5, perl script on 5.6) finds my_print_defaults command from $basedir/{bin,extra}.

Therefore Test::mysqld should set basedir only when mysql_install_db located on {bin,extra}/ directory.