### PR TITLE
Fix basedir detection on mac

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -227,7 +227,7 @@ sub setup {
                 my $base = File::Basename::dirname($mysql_base_dir);
                 $mysql_base_dir = File::Spec->rel2abs(readlink($mysql_base_dir), $base);
             }
-            if ($mysql_base_dir =~ s{/(?:bin|extra)/mysql_install_db$}{}) {
+            if ($mysql_base_dir =~ s{/(?:bin|extra|scripts)/mysql_install_db$}{}) {
                 $cmd .= " --basedir='$mysql_base_dir'";
             }
         }


### PR DESCRIPTION
After recent upgrade to v1.0000, it no longer works on my mac.

```
*** mysql_install_db failed ***
FATAL ERROR: Could not find ./bin/my_print_defaults
...
```

Seems that `mysql_install_db` is located in the `scripts` directory when installing mysql by homebrew.
Since [this patch](https://github.com/kazuho/p5-test-mysqld/pull/20/files#diff-0da6f4918194dda18514d60e6d351571R230) made the detection only work for `bin` and `extra`, the  `--basedir` option does not append correctly.