### PR TITLE
Unbreak basedir detection on osx for homebrew mysql.

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -225,9 +225,9 @@ sub setup {
                 require File::Spec;
                 require File::Basename;
                 my $base = File::Basename::dirname($mysql_base_dir);
-                $mysql_base_dir = File::Spec->rel2abs(readlink($mysql_base_dir), $base);
+                $mysql_base_dir = Cwd::abs_path(File::Spec->rel2abs(readlink($mysql_base_dir), $base));
             }
-            if ($mysql_base_dir =~ s{/(?:bin|extra)/mysql_install_db$}{}) {
+            if ($mysql_base_dir =~ s{/(?:bin|extra|scripts)/mysql_install_db$}{}) {
                 $cmd .= " --basedir='$mysql_base_dir'";
             }
         }


### PR DESCRIPTION
The commit f539aa877f9db03bfd96f12e22fac47d329bb056 breaks
basedir detection on osx for homebrew mysql because homebrew
mysql install mysql_install_db to something like this

    > ls -al $(which mysql_install_db)
    lrwxr-xr-x  1 st21277  admin  27 Feb 26 21:50 /usr/local/opt/mysql@5.6/bin/mysql_install_db -> ../scripts/mysql_install_db

Like on Amazon Linux, this is also a symlink. It is `rel2abs`-ed to be:

    /usr/local/opt/mysql@5.6/bin/mysql_install_db/bin/../scripts/mysql_install_db

... which does not match /(?:bin|extra)/.

In this commit, an extra 'scripts' is append to that regexp. The path
to mysql_install_db is also further collapsed to be

    /usr/local/opt/mysql@5.6/bin/mysql_install_db/scripts/mysql_install_db

... removing the ".." component. This should make further modification
more predictiable as we are now working with the finalized state.