### PR TITLE
`DROP DATABASE` is not needed even if MySQL 8

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -142,12 +142,6 @@ sub wait_for_setup {
     unless ($self->copy_data_from) { # create 'test' database
         my $dbh = DBI->connect($self->dsn(dbname => 'mysql'))
             or die $DBI::errstr;
-        # This 'DROP DATABASE' is only for MySQL8 or later.
-        # MySQL8 or later has "test" database by default and
-        # if `DROP DATABASE` is not done beforehand, `CREATE DATABASE` fails
-        # for some reason on MySQL8 even if `IF NOT EXISTS` notation is there.
-        $dbh->do('DROP DATABASE IF EXISTS test')
-            or die $dbh->errstr;
         $dbh->do('CREATE DATABASE IF NOT EXISTS test')
             or die $dbh->errstr;
     }


### PR DESCRIPTION
It was a misunderstanding...

reverts https://github.com/kazuho/p5-test-mysqld/pull/24