### PR TITLE
Use UNIX socket authentication with MariaDB 10.4.3

### DIFF
--- a/t/01-raii.t
+++ b/t/01-raii.t
@@ -18,7 +18,9 @@ my $dsn = $mysqld->dsn;
 
 is(
     $dsn,
-    "DBI:mysql:dbname=test;mysql_socket=$base_dir/tmp/mysql.sock;user=root",
+    $mysqld->_use_unix_socket_auth ?
+        "DBI:mysql:dbname=test;mysql_socket=$base_dir/tmp/mysql.sock" :
+        "DBI:mysql:dbname=test;mysql_socket=$base_dir/tmp/mysql.sock;user=root",
     'check dsn',
 );
 


### PR DESCRIPTION
MariaDB 10.4.3 changed a default authentication mechanism for UNIX
socket connections. As a result tests stated to fail on failed
authentication.

This patch adjusts dsn() computation and a test to omit the erroneous
user=root parameter.

The same MariaDB also started to enforce setting root password. Since
there is no password management in Test::mysqld, skipped fixing this
part of the code. I only left a comment there.

https://github.com/kazuho/p5-test-mysqld/issues/32