### PR TITLE
Replace `which`  with `command -v` for POSIX-compliant

### DIFF
--- a/lib/Test/mysqld.pm
+++ b/lib/Test/mysqld.pm
@@ -322,7 +322,7 @@ sub _mysql_major_version {
 
 sub _get_path_of {
     my $prog = shift;
-    my $path = `which $prog 2> /dev/null`;
+    my $path = `command -v $prog 2> /dev/null`;
     chomp $path
         if $path;
     $path = ''


### PR DESCRIPTION
In some linux dists (or minimum container images), the which command is not installed by default.

other resource: [POSIXシェルスクリプトではwhichではなくcommand \-vを使うべき理由（＋シェルスクリプト版which） \#Bash \- Qiita](https://qiita.com/ko1nksm/items/60f0c84a0dcbcddc21f6)